### PR TITLE
For an Arch Linux build

### DIFF
--- a/rcore/strings.cc
+++ b/rcore/strings.cc
@@ -437,7 +437,7 @@ static long double
 libc_strtold (const char *nptr, char **endptr)
 {
   const long double result = strtold (nptr, endptr);
-  if (isnan (result) && std::signbit (result) == 0)
+  if (std::isnan (result) && std::signbit (result) == 0)
     {
       const char *p = nptr;
       while (isspace (*p))
@@ -500,9 +500,9 @@ string_to_double (const char *dblstring, const char **endptr)
 String
 string_from_float (float value)
 {
-  if (isnan (value))
+  if (std::isnan (value))
     return std::signbit (value) ? "-NaN" : "+NaN";
-  if (isinf (value))
+  if (std::isinf (value))
     return std::signbit (value) ? "-Infinity" : "+Infinity";
   return string_format ("%.7g", value);
 }
@@ -511,9 +511,9 @@ string_from_float (float value)
 String
 string_from_double (double value)
 {
-  if (isnan (value))
+  if (std::isnan (value))
     return std::signbit (value) ? "-NaN" : "+NaN";
-  if (isinf (value))
+  if (std::isinf (value))
     return std::signbit (value) ? "-Infinity" : "+Infinity";
   return string_format ("%.17g", value);
 }

--- a/rcore/tests/benchrcore.cc
+++ b/rcore/tests/benchrcore.cc
@@ -188,8 +188,8 @@ test_random_numbers()
       const double rf = random_frange (989617512, 9876547656);
       TASSERT (rf >= 989617512 && rf < 9876547656);
     }
-  TASSERT (isnan (random_frange (NAN, 1)));
-  TASSERT (isnan (random_frange (0, NAN)));
+  TASSERT (std::isnan (random_frange (NAN, 1)));
+  TASSERT (std::isnan (random_frange (0, NAN)));
 #if 0 // example penalty paid in random_int64()
   size_t i, j = 0;
   for (i = 0; i < 100; i++)

--- a/rcore/tests/strings.cc
+++ b/rcore/tests/strings.cc
@@ -311,9 +311,9 @@ string_conversions (void)
   TCMP (string_to_double ("-0.5"), ==, -0.5);
   double tfloat;
   tfloat = string_to_double ("+NAN");
-  assert (isnan (tfloat) && std::signbit (tfloat) == 0);
+  assert (std::isnan (tfloat) && std::signbit (tfloat) == 0);
   tfloat = string_to_double ("-NAN");
-  assert (isnan (tfloat) && std::signbit (tfloat) == 1);
+  assert (std::isnan (tfloat) && std::signbit (tfloat) == 1);
   TCMP (string_capitalize ("fOO bar"), ==, "Foo Bar");
   TCMP (string_capitalize ("foo BAR BAZ", 2), ==, "Foo Bar BAZ");
 }

--- a/ui/pixmap.cc
+++ b/ui/pixmap.cc
@@ -5,6 +5,7 @@
 #include <errno.h>
 #include <math.h>
 #include <cstring>
+#include <unistd.h>
 
 #define MAXDIM                          (20480) // MAXDIM*MAXDIM < 536870912
 #define ALIGN_SIZE(size,pow2align)      ((size + (pow2align - 1)) & -pow2align)


### PR DESCRIPTION
This gets past a few errors when building on Arch Linux.

(I'm still too much of a newb to figure out the right LDFLAGS text to specify an older version of libpng, so I've not crossed the finishing line there yet.)