### PR TITLE
Add missing functional include (fix #15)

### DIFF
--- a/rcore/aidasignal.hh
+++ b/rcore/aidasignal.hh
@@ -2,6 +2,8 @@
 #ifndef __RAPICORN_AIDA_SIGNAL_HH__
 #define __RAPICORN_AIDA_SIGNAL_HH__
 
+#include <functional>
+
 namespace Rapicorn { namespace Aida {
 
 namespace Lib {


### PR DESCRIPTION
In order to avoid compile errors like: bind is not a member of std.